### PR TITLE
lib/hash check hashError and not saltError

### DIFF
--- a/src/lib/hash.js
+++ b/src/lib/hash.js
@@ -35,7 +35,7 @@ export async function generatePasswordHash(plainTextPassword) {
     bcrypt.genSalt(ROUNDS, (saltError, salt) => {
       if (saltError) return reject(saltError);
       return bcrypt.hash(plainTextPassword, salt, (hashError, hash) => {
-        if (saltError) return reject(saltError);
+        if (hashError) return reject(hashError);
         return ok(hash);
       });
     });


### PR DESCRIPTION
@ https://github.com/reactql/example-auth/blob/master/src/lib/hash.js#L38
we should test hashError and not saltError